### PR TITLE
Support local repo outside cwd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ var rootCmd = &cobra.Command{
 
 		// if the repo can be parsed as a remote git url, clone it to a temporary directory and use that as the repo path
 		remote, err := vcsurl.Parse(repo)
-		if err == nil {
+		if err == nil && remote.Kind == vcsurl.Git {
 			r, err := remote.Remote(vcsurl.HTTPS)
 			handleError(err)
 

--- a/pkg/gitqlite/gitqlite_test.go
+++ b/pkg/gitqlite/gitqlite_test.go
@@ -97,9 +97,6 @@ func TestCommitCounts(t *testing.T) {
 		t.Fatalf("expected %d columns, got: %d", expected, len(columns))
 	}
 	numRows := getRowsCount(rows)
-	if err != nil {
-		t.Fatal(err)
-	}
 	expected = commitCount
 	if numRows != expected {
 		t.Fatalf("expected %d rows got: %d", expected, numRows)


### PR DESCRIPTION
When querying a local repository with a local file path that is outside of the current working directory the an error appears:

> gitqlite "select committer_email from commits limit 10" --repo /Users/A/valid/local/path/to/git/repo
> unsupported remote protocol

vcsurl can parse the url without error but does not think it is a git repo and on subsequent open throws above error message. Adding an additional check if vcsurl thinks it found a remote git url solves this issue.

