### PR TITLE
fix panic when querying at the empty repository

### DIFF
--- a/pkg/gitqlite/git_log.go
+++ b/pkg/gitqlite/git_log.go
@@ -60,7 +60,8 @@ func (v *gitLogTable) Open() (sqlite3.VTabCursor, error) {
 	v.repo = repo
 	headRef, err := v.repo.Head()
 	if err != nil {
-		return nil, err
+		// the git repository is empty
+		return &commitCursor{0, v.repo, nil, nil, true}, nil
 	}
 
 	iter, err := v.repo.Log(&git.LogOptions{
@@ -186,6 +187,10 @@ func (vc *commitCursor) Filter(idxNum int, idxStr string, vals []interface{}) er
 }
 
 func (vc *commitCursor) Next() error {
+	if vc.commitIter == nil {
+		return nil
+	}
+
 	vc.index++
 
 	commit, err := vc.commitIter.Next()
@@ -211,6 +216,10 @@ func (vc *commitCursor) Rowid() (int64, error) {
 }
 
 func (vc *commitCursor) Close() error {
+	if vc.commitIter == nil {
+		return nil
+	}
+
 	vc.commitIter.Close()
 	return nil
 }

--- a/pkg/gitqlite/git_tree.go
+++ b/pkg/gitqlite/git_tree.go
@@ -171,7 +171,8 @@ func (v *gitTreeTable) Open() (sqlite3.VTabCursor, error) {
 
 	headRef, err := v.repo.Head()
 	if err != nil {
-		return nil, err
+		// the git repository is empty
+		return &commitCursor{0, v.repo, nil, nil, true}, nil
 	}
 	iter, err := v.repo.Log(&git.LogOptions{
 		From:  headRef.Hash(),
@@ -195,6 +196,10 @@ func (v *gitTreeTable) Open() (sqlite3.VTabCursor, error) {
 }
 
 func (vc *treeCursor) Next() error {
+	if vc.iterator == nil {
+		return nil
+	}
+
 	vc.index++
 	//Iterates to next file
 	file, err := vc.iterator.Next()
@@ -223,6 +228,10 @@ func (vc *treeCursor) Rowid() (int64, error) {
 }
 
 func (vc *treeCursor) Close() error {
+	if vc.iterator == nil {
+		return nil
+	}
+
 	vc.iterator.Close()
 	return nil
 }


### PR DESCRIPTION
This PR fixes panic when querying at the empty repository. This is my first Go language work :) I wish I could add a test, but after digging for a few hours, I gave up writing the test case :( Sorry for not adding a test case!

master branch's behavior:
```
$ mkdir empty-git
$ cd empty-git
$ git init
Initialized empty Git repository in /home/youngminz/dist/empty-git-dir/.git/

$ gitqlite "select * from commits"
panic: invalid handle
        panic: invalid handle

goroutine 1 [running]:
github.com/mattn/go-sqlite3.lookupHandleVal(0x0, 0x0, 0x0, 0x0)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/callback.go:128 +0x13d
github.com/mattn/go-sqlite3.lookupHandle(...)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/callback.go:135
github.com/mattn/go-sqlite3.goVClose(0x0, 0x435a61)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/sqlite3_opt_vtable.go:448 +0x2f
github.com/mattn/go-sqlite3._cgoexpwrap_7ec2bdc2f5b0_goVClose(0x0, 0x0)
        _cgo_gotypes.go:1506 +0x64
github.com/mattn/go-sqlite3._Cfunc_sqlite3_finalize(0x29449d8, 0x0)
        _cgo_gotypes.go:962 +0x49
github.com/mattn/go-sqlite3.(*SQLiteStmt).Close.func1(0xc0001227b0, 0x1)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/sqlite3.go:1767 +0x5f
github.com/mattn/go-sqlite3.(*SQLiteStmt).Close(0xc0001227b0, 0x0, 0x0)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/sqlite3.go:1767 +0xac
github.com/mattn/go-sqlite3.(*SQLiteRows).Close(0xc0000aaa20, 0x43520a, 0x7f44b710c6d0)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/sqlite3.go:1956 +0xa7
database/sql.(*Rows).close.func1()
        /usr/lib/go-1.13/src/database/sql/sql.go:3076 +0x3c
database/sql.withLock(0xc45a40, 0xc0000e8280, 0xc0000f3288)
        /usr/lib/go-1.13/src/database/sql/sql.go:3184 +0x6d
database/sql.(*Rows).close(0xc0000e8300, 0x0, 0x0, 0x0, 0x0)
        /usr/lib/go-1.13/src/database/sql/sql.go:3075 +0x129
database/sql.(*Rows).Close(0xc0000e8300, 0xc000124640, 0xc00009d8c0)
        /usr/lib/go-1.13/src/database/sql/sql.go:3059 +0x33
panic(0xa7f040, 0xc31020)
        /usr/lib/go-1.13/src/runtime/panic.go:679 +0x1b2
github.com/mattn/go-sqlite3.lookupHandleVal(0x0, 0x0, 0x0, 0x0)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/callback.go:128 +0x13d
github.com/mattn/go-sqlite3.lookupHandle(...)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/callback.go:135
github.com/mattn/go-sqlite3.goVFilter(0x0, 0x0, 0x2950630, 0x0, 0x29457e8, 0x2)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/sqlite3_opt_vtable.go:464 +0x40
github.com/mattn/go-sqlite3._cgoexpwrap_7ec2bdc2f5b0_goVFilter(0x0, 0x0, 0x2950630, 0x0, 0x29457e8, 0x0)
        _cgo_gotypes.go:1535 +0x9e
github.com/mattn/go-sqlite3._Cfunc__sqlite3_step_internal(0x29449d8, 0x0)
        _cgo_gotypes.go:414 +0x49
github.com/mattn/go-sqlite3.(*SQLiteRows).nextSyncLocked.func1(0xc0000aaa20, 0xc00014a0c0)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/sqlite3.go:2030 +0x62
github.com/mattn/go-sqlite3.(*SQLiteRows).nextSyncLocked(0xc0000aaa20, 0xc00013c1c0, 0xe, 0xe, 0xc00013c1c0, 0xe0)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/sqlite3.go:2030 +0x43
github.com/mattn/go-sqlite3.(*SQLiteRows).Next(0xc0000aaa20, 0xc00013c1c0, 0xe, 0xe, 0x0, 0x0)
        /home/youngminz/go/pkg/mod/github.com/mattn/go-sqlite3@v2.0.3+incompatible/sqlite3.go:2007 +0x2fb
database/sql.(*Rows).nextLocked(0xc0000e8300, 0x430000)
        /usr/lib/go-1.13/src/database/sql/sql.go:2767 +0xd5
database/sql.(*Rows).Next.func1()
        /usr/lib/go-1.13/src/database/sql/sql.go:2745 +0x3c
database/sql.withLock(0xc47100, 0xc0000e8330, 0xc0000f3ad0)
        /usr/lib/go-1.13/src/database/sql/sql.go:3184 +0x6d
database/sql.(*Rows).Next(0xc0000e8300, 0xc00013c000)
        /usr/lib/go-1.13/src/database/sql/sql.go:2744 +0x87
github.com/augmentable-dev/gitqlite/cmd.tableDisplay(0xc0000e8300, 0x43520a, 0xc0000e8300)
        /home/youngminz/dist/gitqlite/cmd/root.go:233 +0x1ba
github.com/augmentable-dev/gitqlite/cmd.displayDB(0xc0000e8300, 0x0, 0xc0000a4000)
        /home/youngminz/dist/gitqlite/cmd/root.go:136 +0x7d
github.com/augmentable-dev/gitqlite/cmd.glob..func1(0x1031420, 0xc00010eaa0, 0x1, 0x1)
        /home/youngminz/dist/gitqlite/cmd/root.go:104 +0x2a6
github.com/spf13/cobra.(*Command).execute(0x1031420, 0xc00009c030, 0x1, 0x1, 0x1031420, 0xc00009c030)
        /home/youngminz/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x1031420, 0x0, 0x0, 0x0)
        /home/youngminz/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
        /home/youngminz/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/augmentable-dev/gitqlite/cmd.Execute()
        /home/youngminz/dist/gitqlite/cmd/root.go:111 +0x2d
main.main()
        /home/youngminz/dist/gitqlite/gitqlite.go:8 +0x20
```

After my fix:
```
$ gitqlite "select * from commits"
repository is empty
```