### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ It's meant for ad-hoc querying of git repositories on disk through a common inte
 ## Installation
 
 ```
-go install -v -tags=sqlite_vtable github.com/augmentable-dev/gitqlite
+go get -v -tags=sqlite_vtable github.com/augmentable-dev/gitqlite
 ```
 
 Will use the go tool chain to install a binary to `$GOBIN`.
 
 ```
-GOBIN=$(pwd) go install -v -tags=sqlite_vtable github.com/augmentable-dev/gitqlite
+GOBIN=$(pwd) go get -v -tags=sqlite_vtable github.com/augmentable-dev/gitqlite
 ```
 
 Will produce a binary in your current directory.


### PR DESCRIPTION
The original command gave the following error (go1.14.3 darwin/amd64):

```
$ go install -v -tags=sqlite_vtable github.com/augmentable-dev/gitqlite
can't load package: package github.com/augmentable-dev/gitqlite: cannot find package "github.com/augmentable-dev/gitqlite" in any of:
	/usr/local/opt/go/libexec/src/github.com/augmentable-dev/gitqlite (from $GOROOT)
	/Users/dloss/golang/src/github.com/augmentable-dev/gitqlite (from $GOPATH)
```